### PR TITLE
Add option to force cache, hence bypassing revalidation checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ async function storeResponseAndReturnClone(
         ? originalPolicyObject
         : {
             ...originalPolicyObject,
-            rescc: { 'must-revalidate': null },
+            rescc: { 'must-revalidate': false },
         };
     const entry = JSON.stringify({
         policy: policyObject,


### PR DESCRIPTION
In preparation for "initial-cache" work to be implemented on Mesh, as per [Mesh#1522](https://github.com/Urigo/graphql-mesh/pull/1522) and [Mesh#1710](https://github.com/Urigo/graphql-mesh/discussions/1710), I am raising this PR to introduce options to force caching.

Force caching implies a way to bypass revalidation checks performed by `http-cache-semantics`, which relies on both request and response headers.

The key points are:
- Bypass ttl check in order to cache entry
- Override cache-control in response header so that it doesn't require revalidation
- Set `max-stale` cache directive in each request in order to allow stale values

The last point is especially important since it needs to be applied to all requests.
Without this, `satisfiesWithoutRevalidation`, will always return false and so a new fetch request will always be instructed, regardless of the cache being available and potentially valid (f.i. within max-age and other directives).

Effectively without the above, we have actually not been taking advantage of caching, since we always need a new fetch to revalidate.

Se [computation of `allowStale`](https://github.com/kornelski/http-cache-semantics/blob/ed83aec75be817967cdac2663907d060fdc6adc3/index.js#L250) in http-cache-semantics